### PR TITLE
style: Fix buttons width

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -16,7 +16,8 @@ header nav ul{
 header nav ul li{
     list-style-type: none;
     border: 2px solid white;
-    width: 13%;
+    /* width: 13%; */
+    width: 8rem;
     display: inline-block;
     text-align: center;
     margin-left: 16px;
@@ -55,7 +56,8 @@ main div ul{
 main div ul li{
     list-style-type: none;
     border: 2px solid white;
-    width: 13%;
+    /* width: 13%; */
+    width: 8rem;
     display: inline-block;
     text-align: center;
     margin-left: 16px;


### PR DESCRIPTION
Os botões estavam quebrando pois foi definido um `width` de 13% para eles. Na tela do computador isso é um tamanho bom, porém para telas de celular isso é muito pouco, o que acaba por não proporcionar o espaço suficiente ao botão e quebra. Para isso, é recomendado usar larguras fixas, como px, rem, em (recomendo o rem). 

Com relação à imagem, recomendo trocar de svg para jpg e procurar uma imagem com o desenho dela menor, pois com a propriedade `background-size: cover;` a imagem ocupa a tela toda, o que acaba por dar um zoom na imagem, por isso que no celular fica bom, uma vez que sua largura é menor.

Se precisar de algo mais é só chamar. Sucesso!!