### PR TITLE
style: Fix buttons width

### DIFF
--- a/layout.css
+++ b/layout.css
@@ -16,7 +16,8 @@ header nav ul{
 header nav ul li{
     list-style-type: none;
     border: 2px solid white;
-    width: 13%;
+    /* width: 13%; */
+    width: 8rem;
     display: inline-block;
     text-align: center;
     margin-left: 16px;
@@ -55,7 +56,8 @@ main div ul{
 main div ul li{
     list-style-type: none;
     border: 2px solid white;
-    width: 13%;
+    /* width: 13%; */
+    width: 8rem;
     display: inline-block;
     text-align: center;
     margin-left: 16px;


### PR DESCRIPTION
Os botões estavam quebrando pois foi definido um `width` de 13% para eles. Na tela do computador é um tamanho bom, mas no celular é muito pequeno, o que acaba por não proporcionar espaço suficiente ao botão. Para isso é recomendado usar unidades fixas, como px, rem, em (recomendo o rem).

Quanto à imagem, recomendo trocar de svg para jpg e procurar uma imagem com um desenho menor, pois é aplicado a propriedade `background-size: cover;`, fazendo com que a imagem ocupe a largura inteira da tela, dando um zoom nela para isso, por isso que no celular fica com um tamanho bom, uma vez que a largura da tela do celular é manor.

Se precisar de mais alguma coisa é só chamar. Sucesso!!